### PR TITLE
Fix MCP SSE endpoint: mcp SDK 2.0.0 incompatibility + doubled /mcp/mcp/messages/ path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,12 @@ dependencies = [
     "PyYAML>=6.0.1",
     "ruamel.yaml>=0.18.0",
     "SQLAlchemy>=2.0.0",
-    "mcp>=1.0.0",
+    # pyrite/server/mcp_server.py's build_sdk_server() uses the mcp SDK's
+    # 1.x low-level Server API (e.g. Server.list_tools() as a decorator),
+    # which the SDK's 2.0.0 release removed/renamed. An unbounded install
+    # picks up 2.0.0 and every MCP request 500s with
+    # AttributeError: 'Server' object has no attribute 'list_tools'.
+    "mcp>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyrite/server/mcp_routes.py
+++ b/pyrite/server/mcp_routes.py
@@ -137,9 +137,12 @@ def mount_mcp_routes(
 
     from .mcp_server import PyriteMCPServer
 
-    # The SSE transport expects a relative path for the message endpoint.
-    # Clients POST to this path with a session_id query parameter.
-    sse_transport = SseServerTransport("/mcp/messages/")
+    # SseServerTransport prepends scope["root_path"] (which is "/mcp" here,
+    # since this whole app is nested under Mount("/mcp", ...) below) to this
+    # endpoint to build the client-facing POST path. Passing "/mcp/messages/"
+    # here double-prefixes it to "/mcp/mcp/messages/", which 404s — the
+    # endpoint must be relative to the mount point, i.e. just "/messages/".
+    sse_transport = SseServerTransport("/messages/")
 
     # Cache MCP server instances per tier to avoid repeated heavy init.
     _mcp_servers: dict[str, PyriteMCPServer] = {}


### PR DESCRIPTION
## Summary

Deployed pyrite fresh from `dev` and found the MCP SSE endpoint (`GET /mcp/sse`) completely broken end-to-end for a real client (Claude Code). Two independent bugs, both fixed here:

### 1. `mcp` SDK 2.0.0 breaks `build_sdk_server()`

`pyproject.toml` declares `mcp>=1.0.0` with no upper bound. `mcp` released `2.0.0` recently, which removed/renamed the low-level `Server` API that `pyrite/server/mcp_server.py`'s `build_sdk_server()` uses (`@sdk.list_tools()` etc.). A fresh install resolves `mcp==2.0.0` and every request to `/mcp/sse` 500s:

```
File "pyrite/server/mcp_server.py", line 1702, in build_sdk_server
    @sdk.list_tools()
     ^^^^^^^^^^^^^^
AttributeError: 'Server' object has no attribute 'list_tools'
```

Fix: pin `mcp>=1.0.0,<2.0.0` until the code is ported to the 2.x API.

### 2. Doubled `/mcp/mcp/messages/` POST endpoint path

Even with the SDK pinned, the SSE handshake succeeds but the session dies immediately after: the client's first POST 404s.

`mount_mcp_routes()` nests the whole SSE app under `Mount("/mcp", routes=[..., Mount("/messages/", ...)])`, but constructs `SseServerTransport("/mcp/messages/")` — a path that *already* includes the outer mount's prefix. `SseServerTransport.connect_sse()` (mcp SDK's `sse.py`) builds the client-facing endpoint as `scope["root_path"].rstrip("/") + self._endpoint`, and `scope["root_path"]` is already `"/mcp"` by the time it runs (from the outer `Mount`). So the emitted `event: endpoint` ends up pointing at `/mcp/mcp/messages/?session_id=...`, which isn't a registered route.

Fix: construct the transport with a path relative to the mount point — `"/messages/"` — matching the inner `Mount("/messages/", ...)` alongside it.

## Verification

Built the image from this branch, deployed it, and confirmed:
- `GET /mcp/sse` with a valid Bearer token now returns `200` with a real `text/event-stream` session (previously `500`)
- The emitted `event: endpoint` now reads `/mcp/messages/?session_id=...` (previously `/mcp/mcp/messages/?session_id=...`, which 404'd)
- `claude mcp list` now shows the server as `✔ Connected` end-to-end from Claude Code (previously failed on both bugs in turn)

## Test plan

- [ ] `pip install ".[server]"` in a clean environment and confirm `mcp<2.0.0` is what gets resolved
- [ ] Start the server, connect an MCP client over SSE, confirm the `endpoint` event path and that a tool call round-trips successfully