### PR TITLE
Fix: KB created via POST /api/kbs is invisible to entry creation until restart

### DIFF
--- a/pyrite/services/kb_registry_service.py
+++ b/pyrite/services/kb_registry_service.py
@@ -128,6 +128,27 @@ class KBRegistryService:
             description=description,
             source="user",
         )
+
+        # config._db_kb_cache is only populated once, on first DB access
+        # (create_app()'s _app_get_db() calls db.merge_registered_kbs()
+        # lazily and then never again). Without this, a KB registered here
+        # is invisible to config.get_kb()/all_kbs() -- and therefore to
+        # KBService.get_kb() and entry creation -- for the rest of this
+        # process's life, even though it's already committed to the DB.
+        # Update the in-memory cache immediately so it's usable in the same
+        # request/process, not just after a restart.
+        self.config.register_db_kbs(
+            [
+                {
+                    "name": name,
+                    "path": str(resolved),
+                    "kb_type": kb_type,
+                    "description": description,
+                    "default_role": None,
+                }
+            ]
+        )
+
         return self.get_kb(name)  # type: ignore[return-value]
 
     def _apply_preset(self, kb_path: Path, name: str, kb_type: str, description: str) -> None:


### PR DESCRIPTION
## Summary

Related to (but narrower than) #collapse-kb-registry-to-one-source-of-truth: creating a KB via `POST /api/kbs` (or the `KBRegistryService.add_kb()` path generally) writes it to the DB successfully, but the very next `POST /api/entries` against that KB fails with:

```json
{"detail":{"code":"KB_NOT_FOUND","message":"KB 'homelab' not found"}}
```

...until the server process is restarted, at which point it works fine.

## Root cause

`PyriteConfig._db_kb_cache` — the fallback lookup `get_kb()`/`all_kbs()` use for DB-registered (as opposed to `config.yaml`-declared) KBs — is only populated **once**: `create_app()`'s `_app_get_db()` closure calls `db.merge_registered_kbs(cfg)` lazily on the first request that touches the DB, then caches `application.state.pyrite_db` and never calls it again for the lifetime of the process.

`KBRegistryService.add_kb()` writes the new KB straight to the `kb` table via `db.register_kb()`, but never touches `config._db_kb_cache`. Since `KBService.get_kb()` and `PyriteConfig.get_kb()` both resolve DB-only KBs through that in-memory cache (not a live DB query), the newly-created KB is invisible to every KB-name lookup that goes through `config` — including entry creation — for the rest of the process's life, even though it's already committed to the database. A CLI invocation (`pyrite kb add`) works around this by nature, since each CLI run calls `load_config()` fresh and re-merges from the DB.

## Fix

`add_kb()` now calls `self.config.register_db_kbs([...])` with the newly-registered KB immediately after the DB write, so the in-memory cache reflects it in the same process — no restart needed.

## Verification

Reproduced against a live deployment: `POST /api/kbs` to create a KB, then immediately `POST /api/entries` against it → `404 KB_NOT_FOUND`. Only a full pod restart made the KB usable. With this fix, built and deployed, the same create-KB-then-immediately-write-an-entry sequence succeeds without any restart.

## Test plan

- [ ] `POST /api/kbs` to create a new KB, then immediately `POST /api/entries` against it in the same process — should succeed, not 404
- [ ] Existing `tests/test_kb_registry_service.py` / `tests/test_services.py` coverage for `add_kb()` still passes