### PR TITLE
Fix: EmbeddingService.prewarm() is never called despite PYRITE_PREWARM_EMBEDDINGS=true

### DIFF
--- a/pyrite/server/api.py
+++ b/pyrite/server/api.py
@@ -727,13 +727,32 @@ def create_app(config: PyriteConfig | None = None) -> FastAPI:
     except Exception:
         logger.warning("Failed to seed KB registry from config", exc_info=True)
 
-    # Set up embedding service for prewarm (actual prewarm happens in lifespan)
+    # Set up embedding service for prewarm and actually pre-warm it on startup.
+    # This used to only construct the EmbeddingService and stop -- the comment
+    # said "actual prewarm happens in lifespan" but no lifespan/startup hook
+    # ever called .prewarm(), so /health's embeddings.ready stayed false
+    # forever and the first real search/embed request always paid the full
+    # cold-start cost this feature exists to avoid. Runs in a thread since
+    # prewarm() is a blocking sentence-transformers model load.
     if config.settings.prewarm_embeddings:
         from ..services.embedding_service import EmbeddingService
 
         application.state.pyrite_embedding_svc = EmbeddingService(
             _app_get_db(), model_name=config.settings.embedding_model
         )
+
+        @application.on_event("startup")
+        async def _prewarm_embedding_model() -> None:
+            from starlette.concurrency import run_in_threadpool
+
+            warmed = await run_in_threadpool(application.state.pyrite_embedding_svc.prewarm)
+            if warmed:
+                logger.info("Embedding model pre-warmed on startup")
+            else:
+                logger.warning(
+                    "Embedding model pre-warm failed or unavailable "
+                    "(sentence-transformers not installed?)"
+                )
 
     # CORS — use configured origins; disable credentials with wildcard (spec compliance)
     origins = config.settings.cors_origins


### PR DESCRIPTION
## Summary

`PYRITE_PREWARM_EMBEDDINGS=true` constructs an `EmbeddingService` and stores it on `application.state.pyrite_embedding_svc`, next to a comment claiming "actual prewarm happens in lifespan" — but `create_app()` never registers a lifespan handler or startup event that calls `.prewarm()` on it. Searched the whole file: no `.prewarm(` call, no `lifespan=` passed to `FastAPI(...)`.

The practical effect:
- `/health`'s `embeddings.ready` field (which just reads `.is_warm`) stays `false` forever — confirmed on a live deployment: idle CPU, flat ~100MB RSS, `embeddings.ready:false` minutes after startup, even after issuing a `mode=hybrid` search request.
- The cold-start cost this feature exists to avoid (per the original ticket, `kb/backlog/done/embedding-service-prewarm.md`, marked `status: done`) is instead paid by whichever request happens to trigger the first lazy model load.

## Fix

Add the missing `@application.on_event("startup")` hook, calling `.prewarm()` in a thread pool (it's a blocking `sentence-transformers` model load, so running it directly in the async handler would stall the event loop).

## A caveat worth knowing about

`KBService._get_embedding_svc()` lazily constructs its **own separate** `EmbeddingService` instance for actual search/embed calls — it doesn't reuse `application.state.pyrite_embedding_svc`. So this fix doesn't make `/health`'s ready-flag track the *exact* instance driving search requests. It does, though:
1. Make the health field finally reflect real prewarm state (rather than being permanently `false`/dead), and
2. Warm the `sentence-transformers` model + HuggingFace disk cache during startup, so `KBService`'s own first lazy load hits a warm cache instead of a fresh download+init — meaningfully cutting the actual cold-start latency even though it's technically a second in-memory model instance.

A more complete fix would unify these into a single shared instance (e.g. via DI), but that's a larger change than this ticket's scope — flagging it here in case a maintainer wants to fold it into a follow-up.

## Verification

Confirmed the bug is real by direct inspection (no `.prewarm(` call anywhere in `pyrite/server/api.py`, no `lifespan=`) and by observing the symptom live: pod idle, health field permanently false, no warmup activity in logs even minutes post-startup.

## Test plan

- [ ] Set `PYRITE_PREWARM_EMBEDDINGS=true`, start the server, confirm `/health`'s `embeddings.ready` becomes `true` shortly after startup (not permanently `false`)
- [ ] Confirm startup logs show either "Embedding model pre-warmed on startup" or the failure warning
- [ ] Confirm server startup still completes normally when `sentence-transformers` is unavailable (prewarm returns `False`, doesn't raise)